### PR TITLE
Update utility tools

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,5 @@ extern crate proptest;
 #[cfg(test)]
 extern crate float_cmp;
 
-pub mod utility;
+mod utility;
+pub use utility::*;

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -394,6 +394,16 @@ impl Linspace {
         }
     }
 
+    /// Inclusive range iterator over the range 0 to 1 with the desired number of elements
+    ///
+    /// If numerical precision and the exact number of elements is less important than speed, try
+    /// [`Stepper`] instead.
+    ///
+    /// [`Stepper`]: struct.Stepper.html
+    pub fn normal(numel: usize) -> Self {
+        Self::new(0., 1., numel)
+    }
+
 
     /// Create inclusive range iterater with a stepsize approximately equal to `step`
     pub fn with_stepsize(start: f64, end: f64, step: f64) -> Self {

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -184,6 +184,11 @@ impl Stepper {
             dt,
         }
     }
+
+    pub fn restart(&mut self) -> &Self {
+        self.t = 0.;
+        self
+    }
 }
 
 impl Iterator for Stepper {

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -480,6 +480,10 @@ mod linspace_iterator {
     use std::f64::EPSILON;
     use super::Linspace;
 
+    fn is_bounds(el: f64, min: f64, max: f64) -> bool {
+        el.approx_eq(&min, 3.*EPSILON, 3) || el.approx_eq(&max, 3.*EPSILON, 3)
+    }
+
     fn arb_bounds() -> impl Strategy<Value = (f64, f64)> {
         (any::<f64>(), any::<f64>())
     }
@@ -548,8 +552,7 @@ mod linspace_iterator {
             let linspace = Linspace::new(start, end, n);
             for el in linspace {
                 assert! {
-                    (min < el && el < max) ||
-                        (el.approx_eq(&min, 3.*EPSILON, 3) || el.approx_eq(&max, 3.*EPSILON, 3)),
+                    (min < el && el < max) || is_bounds(el, min, max),
                     "el {:e} outside range [{:e}, {:e}]",
                     el,
                     min,

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -1,4 +1,5 @@
-//! Utility functions to use in conjunction with the curve interpolation tools.
+//! Utility functions to use alongside and drive non-linear transforms
+
 
 use std::iter::Iterator;
 
@@ -14,8 +15,7 @@ use std::iter::Iterator;
 ///
 /// # Examples
 ///
-/// Starting with a simple polynomial _p(x) = x^2 + 6x + 3_, we make a vector
-/// of its coefficients.
+/// Starting with a simple polynomial _p(x) = x^2 + 6x + 3_, we make a vector of its coefficients.
 ///
 /// ```
 /// # use camber::utility::poly_eval;
@@ -25,9 +25,8 @@ use std::iter::Iterator;
 /// # assert!(poly_eval(&poly, 1.) == 10.);
 /// ```
 ///
-/// The easiest two points solve for by hand are usually _1_ and _0_; for our
-/// particular polynomial, _p(0) = 3_ and _p(1) = 10_.  Running `poly_eval` with
-/// these in mind we have:
+/// The easiest two points solve for by hand are usually _1_ and _0_; for our particular
+/// polynomial, _p(0) = 3_ and _p(1) = 10_.  Running `poly_eval` with these in mind we have:
 ///
 /// ```
 /// # use camber::utility::poly_eval;
@@ -37,17 +36,17 @@ use std::iter::Iterator;
 /// assert!(poly_eval(&poly, 1.) == 10.);
 /// ```
 ///
-/// `poly_eval` is especially useful in cases where you have interpolated a
-/// polynomial with some method and have obtained a list of coefficients and
-/// want to get those values over a range.  Using the same polynomial from
-/// before we can do things like evaluate values from _0_ to _10_ with steps of
-/// _0.1_.
+/// `poly_eval` is especially useful in cases where you have interpolated a polynomial with some
+/// method and have obtained a list of coefficients and want to get those values over a range.
+/// Using the same polynomial from before we can do things like evaluate values from _0_ to _10_
+/// with 10 steps.
 ///
 /// ```
 /// # use camber::utility::poly_eval;
+/// use camber::utility::Linspace;
 /// # let poly = vec![1.,6.,3.];
 /// #
-/// (0..100).map(|x| poly_eval(&poly, f64::from(x)*0.1));
+/// Linspace::new(0., 10., 10).map(|x| poly_eval(&poly, f64::from(x)*0.1));
 /// ```
 ///
 pub fn poly_eval(coefficients: &[f64], x: f64) -> f64 {
@@ -84,7 +83,13 @@ mod poly_eval {
     }
 }
 
-/// Step across the inclusive range from `0` to `1` with a set number of steps or stepsize
+/// Iterator over the range [0, 1] with a set number of steps or stepsize
+///
+/// # See Also
+///
+/// - [`Linspace`]
+///
+/// # Examples
 ///
 /// No matter what stepsize is chosen, the stepper will always run through at least one iteration
 /// starting at exactly zero.
@@ -94,6 +99,8 @@ mod poly_eval {
 /// assert_eq!(Some(0.), Stepper::new(1e1000).next());
 /// assert_eq!(Some(0.), Stepper::new(1e-16).next());
 /// ```
+///
+/// [`Linspace`]: struct.Linspace.html
 pub struct Stepper {
     t: f64,
     dt: f64,
@@ -250,6 +257,10 @@ fn lerp(a: f64, b: f64, t: f64) -> f64 {
 /// - `end`: The last value of the range
 /// - `numel`: The number of elements in the range
 ///
+/// # See Also
+///
+/// - [`Linspace`]
+///
 /// # Examples
 ///
 /// To get 100 floating point numbers between zero and one, including zero and
@@ -272,6 +283,8 @@ fn lerp(a: f64, b: f64, t: f64) -> f64 {
 ///     .map(|t| poly_eval(&poly,*t)) // f(x) = x^2
 ///     .collect();
 /// ```
+///
+/// [`Linspace`]: struct.Linspace.html
 pub fn linspace(start: f64, end: f64, numel: u32) -> Vec<f64> {
     if numel == 0 { return Vec::new(); }
     // Given some desired start _s_ and end _e_, parameterize
@@ -337,6 +350,11 @@ mod linspace {
 /// to stay within the start and end bounds.  It's useful for providing linear ranges over which to
 /// evaluate 1D transforms or polynomials.
 ///
+/// # See Also
+///
+/// - [`Stepper`]
+/// - [`linspace`]
+///
 /// # Examples
 ///
 /// A range with zero elements simply `None` forever.
@@ -357,11 +375,11 @@ mod linspace {
 ///
 /// let mut ts = Linspace::new(-1., 1., 50);
 /// let coeffients = [1., 5., 32., 1.];
-/// let ys: Vec<f64> = ts.map(|t| poly_eval(&coeffients, t)).collect();
+/// let ts: Vec<f64> = ts.map(|t| poly_eval(&coeffients, t)).collect();
 /// ```
 ///
-/// This is better than using the `linspace` function as it does not allocate a vector which could
-/// be wastefull
+/// [`linspace`]: fn.linspace.html
+/// [`Stepper`]: struct.Stepper.html
 #[derive(Debug, Clone, Copy)]
 pub struct Linspace {
     start: f64,

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -336,7 +336,8 @@ mod linspace_iterator {
         fn one_element((start, end) in arb_bounds()) {
             let linspace = Linspace::new(start, end, 1);
 
-            for el in linspace {
+            for (i, el) in linspace.enumerate() {
+                assert!(i < 2, "{:?}", linspace);
                 assert!(end.approx_eq(&el, 2.*EPSILON, 2))
             }
         }
@@ -349,13 +350,24 @@ mod linspace_iterator {
         }
 
         #[test]
+        fn correct_first_element((start, end) in arb_bounds(), n in arb_length()) {
+            let mut linspace = Linspace::new(start, end, n);
+            let first = linspace.next().expect("Last element must exist");
+            assert!(first.approx_eq(&start, 3.*EPSILON, 3))
+        }
+
+        #[test]
         fn correct_end_element((start, end) in arb_bounds(), n in arb_length()) {
             let range = Linspace::new(start, end, n);
             let mut tf = 0.;
-            for t in range {
+            for (i, t) in range.enumerate() {
+                assert!(i <= n, "t_{} of {}: {:e}", i, n, t);
                 tf = t;
             }
-            assert_eq!(tf, end);
+            assert!(
+                tf.approx_eq(&end, 3.*EPSILON, 3),
+                "tf: {:e} != {:e}", tf, end
+            );
         }
 
         #[test]

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -264,8 +264,12 @@ mod stepper {
         #[test]
         fn approx_right_numel(n in 1..100_000usize) {
             let total = Stepper::with_numel(n).count();
-            let proportion = total as f64 / n as f64;
-            let pass = proportion > 0.95;
+            let pass = if n > 100 {
+                let proportion = total as f64 / n as f64;
+                proportion > 0.99
+            } else {
+                total + 1 == n || total == n
+            };
             assert!(pass, "total {} doesn't approximate set number of elements {}", total, n);
         }
     }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -4,8 +4,9 @@ use std::iter::Iterator;
 
 /// Evaluate a polynomial from its coefficients
 ///
-/// A polynomial of degree _n_ has _n_+1 coefficients.  Providing a single
-/// coefficient is the same as a constant function.
+/// A polynomial of degree _n_ has _n_+1 coefficients.  Providing a single coefficient is the same
+/// as a constant function.
+///
 /// Achieves O(n) time complexity given n coefficients using _Horner's Rule_.
 ///
 /// - `coefficients`: vector of coeffients in the order `a[n] .. a[0]`

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -303,6 +303,13 @@ mod linspace {
     }
 
     #[test]
+    fn backwards() {
+        let xs = linspace(2., -2., 2);
+        assert_eq!(xs[0], 2.);
+        assert_eq!(xs[1], -2.);
+    }
+
+    #[test]
     fn constant_range() {
         for el in linspace(1.,1.,1000000) {
             assert_eq!(el,1.);


### PR DESCRIPTION
Add a `Linspace` struct and `Stepper` struct for using the iterator interface to interpolate rather than using vectors.