### PR TITLE
Fix error in example which triggered builds to fail in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Camber
 
-[![Build Status](https://travis-ci.org/glfmn/camber.svg?branch=master)](https://travis-ci.org/Lionex/camber)
+[![Build Status](https://travis-ci.org/glfmn/camber.svg?branch=master)](https://travis-ci.org/glfmn/camber)
 
 > **Camber**: _v._ to curve
 

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -5,7 +5,7 @@ use plotlib::style::Line;
 use plotlib::page::Page;
 use plotlib::view::View;
 use plotlib::function::{ Function, Style };
-use camber::utility::poly_eval;
+use camber::poly_eval;
 
 fn main() {
     let linear = [1., 0.];


### PR DESCRIPTION
Specifically, the example imported from a module which no longer exists and is now re-exported at the crate root.